### PR TITLE
chore: add current date and time to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,5 @@ Start the app with:
 `$ OTEL_LOGS_EXPORTER=otlp OTEL_METRICS_EXPORTER=otlp OTEL_METRIC_EXPORT_INTERVAL=20000 OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative PORT=3001 bundle exec rails server`
 
 (Or use the dotenv-rails gem and set these in the .env.development file.)
+
+Last updated: 2026-04-09 22:06:14 UTC


### PR DESCRIPTION
## Description
Adds the current date and time (2026-04-09 22:06:14 UTC) to the bottom of the README.md file as requested in the agent-projects PLAN.md.

## Test Plan
- [ ] Verify the timestamp appears at the bottom of README.md

_Opened collaboratively by Wendy Smoak and open-swe._